### PR TITLE
Bugfix and updates for more accurate date selection

### DIFF
--- a/lib/ae_bank_days/bank_day_helper.rb
+++ b/lib/ae_bank_days/bank_day_helper.rb
@@ -12,22 +12,24 @@ module AeBankDays
 
       def next_banking_day(date, number_of_days: 0)
         banking_day = date.to_date
+        banking_day += 1
         number_of_days.times do
-          banking_day += 1 until bank_day?(banking_day)
+          banking_day = current_or_next_banking_day(banking_day)
           banking_day += 1
         end
-        banking_day += 1 until bank_day?(banking_day)
-        banking_day
+
+        current_or_next_banking_day(banking_day)
       end
 
       def previous_banking_day(date, number_of_days: 0)
         banking_day = date.to_date
+        banking_day -= 1
         number_of_days.times do
-          banking_day -= 1 until bank_day?(banking_day)
+          banking_day = current_or_previous_banking_day(banking_day)
           banking_day -= 1
         end
-        banking_day -= 1 until bank_day?(banking_day)
-        banking_day
+
+        current_or_previous_banking_day(banking_day)
       end
 
       def current_or_previous_banking_day(day)

--- a/lib/ae_bank_days/bank_day_helper.rb
+++ b/lib/ae_bank_days/bank_day_helper.rb
@@ -11,7 +11,7 @@ module AeBankDays
       end
 
       def next_banking_day(date, number_of_days: 0)
-        banking_day = date
+        banking_day = date.to_date
         number_of_days.times do
           banking_day += 1 until bank_day?(banking_day)
           banking_day += 1
@@ -21,7 +21,7 @@ module AeBankDays
       end
 
       def previous_banking_day(date, number_of_days: 0)
-        banking_day = date
+        banking_day = date.to_date
         number_of_days.times do
           banking_day -= 1 until bank_day?(banking_day)
           banking_day -= 1

--- a/lib/ae_bank_days/bank_day_helper.rb
+++ b/lib/ae_bank_days/bank_day_helper.rb
@@ -30,6 +30,18 @@ module AeBankDays
         banking_day
       end
 
+      def current_or_previous_banking_day(day)
+        date = day.to_date
+        date -= 1 until bank_day?(date)
+        date
+      end
+
+      def current_or_next_banking_day(day)
+        date = day.to_date
+        date += 1 until bank_day?(date)
+        date
+      end
+
       private
 
       def weekday?(day)

--- a/lib/ae_bank_days/version.rb
+++ b/lib/ae_bank_days/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AeBankDays
-  VERSION = '2.0.0'
+  VERSION = '1.3.0'
 end

--- a/lib/ae_bank_days/version.rb
+++ b/lib/ae_bank_days/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AeBankDays
-  VERSION = '1.3.0'
+  VERSION = '2.0.0'
 end

--- a/test/ae_bank_days/bank_day_helper_test.rb
+++ b/test/ae_bank_days/bank_day_helper_test.rb
@@ -16,6 +16,10 @@ module AeBankDays
       refute BankDayHelper.bank_day?(Date.civil(2017, 10, 9))
     end
 
+    def test_bank_day__weekday_time
+      assert BankDayHelper.bank_day?(Time.new(2017, 10, 3))
+    end
+
     def test_bank_day__saturday_holiday_is_not_observed_on_friday
       # The federal bank does not observe holidays that fall on Saturday on the preceding Friday as is common.
       # This test makes sure that these dates are not accidentally marked as holidays.
@@ -70,6 +74,22 @@ module AeBankDays
 
     def test_previous_banking_day__holiday__extra_days
       assert_equal Date.civil(2017, 10, 3), BankDayHelper.previous_banking_day(Date.civil(2017, 10, 9), number_of_days: 3)
+    end
+
+    def test_current_or_previous_banking_day
+      date = Date.new(2016, 1, 21)
+      assert_equal date, BankDayHelper.current_or_previous_banking_day(date)
+
+      date = Date.new(2016, 1, 17)
+      assert_equal Date.new(2016, 1, 15), BankDayHelper.current_or_previous_banking_day(date)
+    end
+
+    def test_current_or_next_banking_day
+      date = Date.new(2016, 1, 21)
+      assert_equal date, BankDayHelper.current_or_next_banking_day(date)
+
+      date = Date.new(2016, 1, 17)
+      assert_equal Date.new(2016, 1, 19), BankDayHelper.current_or_next_banking_day(date)
     end
   end
 end

--- a/test/ae_bank_days/bank_day_helper_test.rb
+++ b/test/ae_bank_days/bank_day_helper_test.rb
@@ -29,11 +29,11 @@ module AeBankDays
     end
 
     def test_next_banking_day__weekday
-      assert_equal Date.civil(2017, 10, 3), BankDayHelper.next_banking_day(Date.civil(2017, 10, 3))
+      assert_equal Date.civil(2017, 10, 4), BankDayHelper.next_banking_day(Date.civil(2017, 10, 3))
     end
 
     def test_next_banking_day__weekday__extra_days
-      assert_equal Date.civil(2017, 10, 6), BankDayHelper.next_banking_day(Date.civil(2017, 10, 3), number_of_days: 3)
+      assert_equal Date.civil(2017, 10, 10), BankDayHelper.next_banking_day(Date.civil(2017, 10, 3), number_of_days: 3)
     end
 
     def test_next_banking_day__weekend
@@ -53,11 +53,11 @@ module AeBankDays
     end
 
     def test_previous_banking_day__weekday
-      assert_equal Date.civil(2017, 10, 3), BankDayHelper.previous_banking_day(Date.civil(2017, 10, 3))
+      assert_equal Date.civil(2017, 10, 2), BankDayHelper.previous_banking_day(Date.civil(2017, 10, 3))
     end
 
     def test_previous_banking_day__weekday__extra_days
-      assert_equal Date.civil(2017, 10, 3), BankDayHelper.previous_banking_day(Date.civil(2017, 10, 6), number_of_days: 3)
+      assert_equal Date.civil(2017, 10, 2), BankDayHelper.previous_banking_day(Date.civil(2017, 10, 6), number_of_days: 3)
     end
 
     def test_previous_banking_day__weekend


### PR DESCRIPTION
This PR casts all arguments to `next_banking_day` and `previous_banking_day` to a date to improve performance and ensure we are always incrementing on Date objects. 