### PR TITLE
PAYZ-97: add required config for dev portal

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: Publish documentation
+
+on:
+  push:
+
+    # Publish documentation updates when associated code is merged to master
+    # or an alternative trunk-like branch in case its changed in the future
+    branches:
+      - master
+      - main
+
+    # Only execute publishing workflow if documentation is updated (Optional)
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/docs.yml
+
+jobs:
+  docs:
+    uses: appfolio/developer-knowledge-platform/.github/workflows/backstage-techdocs-publish.yml@latest
+    with:
+      entity_name: ae-bank-days
+    secrets: inherit

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# AE_Bank_Days
+
+## WIP - Entry page for developer portal

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: ${{ values.name }}
+site_description: ${{ values.description }}
+
+repo_url: https://github.com/appfolio/ae_bank_days
+
+# Instructions for adding pages below:
+#   https://developer.appf.io/docs/default/domain/developer-knowledge-platform/techdocs/setup/repository/
+#   https://developer.appf.io/docs/default/domain/developer-knowledge-platform/techdocs/authoring/navigation/
+nav:
+  - Home: index.md
+
+plugins:
+  - techdocs-core
+  - include-markdown


### PR DESCRIPTION
Required repos and files for backstage/dev portal. This is to be used for the docs-as-code pattern and be rendered to the dev portal on documentation changes