### PR TITLE
PAYZ-120: Adding a page to trigger docs action

### DIFF
--- a/docs/how_to_run.md
+++ b/docs/how_to_run.md
@@ -1,0 +1,9 @@
+---
+author: bank-sinatra
+---
+
+<!--- https://developer.appf.io/docs/default/domain/developer-knowledge-platform/techdocs/authoring/include_markdown/ -->
+{%
+  include-markdown "../README.md"
+  rewrite-relative-urls=true
+%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ repo_url: https://github.com/appfolio/ae_bank_days
 #   https://developer.appf.io/docs/default/domain/developer-knowledge-platform/techdocs/authoring/navigation/
 nav:
   - Home: index.md
+  - How to run: how_to_run.md
 
 plugins:
   - techdocs-core


### PR DESCRIPTION
The previous action failure may have been an anomaly. This is mainly to re-trigger the action for testing