### PR TITLE
[KNOW-138] Replace docs publishing workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   docs:
-    uses: appfolio/developer-knowledge-platform/.github/workflows/backstage-techdocs-publish.yml@latest
+    uses: appfolio/developer-knowledge-platform/.github/workflows/docs-deploy.yml@latest
     with:
       entity_name: ae-bank-days
     secrets: inherit


### PR DESCRIPTION
This is a Sourcegraph-generated change that replaces a deprecated
docs publishing GitHub Actions workflow file with a new supported
version.

[_Created by Sourcegraph batch change `modethirteen/update-docs-publishing-workflow`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/update-docs-publishing-workflow)