### PR TITLE
Add Backstage catalog metadata file(s)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  title: ae_bank_days
+  description: Simple utility gem to find the next banking day
+  tags:
+    - oss
+  annotations:
+    appfolio.com/package-location: url:https://rubygems.org/gems/ae_bank_days
+    appfolio.com/package-type: gem
+    circleci.com/project-slug: github/appfolio/ae_bank_days
+  name: ae-bank-days
+spec:
+  type: library
+  lifecycle: maintenance
+  owner: bank-sinatra


### PR DESCRIPTION
All Backstage component, resource, and api catalog metadata files are migrating to project repositories to lower the rate of effort for catalog maintenance.

[_Created by Sourcegraph batch change `modethirteen/migrate-developer-portal-catalog-open-source-metadata`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/migrate-developer-portal-catalog-open-source-metadata)