### PR TITLE
[BANK-2106] Migrate gem source from RubyGems to JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,14 @@ version: 2.1
 
 orbs:
   gem-tool: appfolio/gem-tool@volatile
+  public-packages: https://raw.githubusercontent.com/appfolio/public-packages/v1/orbs/public-packages.yml
 
 workflows:
   rc:
     jobs:
       - gem-tool/rake_test:
           name: test_ruby-<< matrix.ruby_version >>
+          context: appfolio_test_context
           executor_tag: ruby
           matrix:
             parameters:
@@ -15,6 +17,8 @@ workflows:
                 - '4.0.1'
                 - '3.4.8'
                 - '3.3.10'
+          after-checkout-steps:
+            - public-packages/setup
           after-appraisal-install-steps:
             - run:
                 name: Run Rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' # global source
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_bank_days-gem/' # global source
 
-source 'https://rubygems.org' do
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_bank_days-gem/' do
   gem 'appraisal', '>= 2.5', '< 3'
   gem 'bundler', '>= 2.6', '< 5'
   gem 'minitest', '>= 5.27', '< 6'

--- a/ae_bank_days.gemspec
+++ b/ae_bank_days.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = Gem::Requirement.new('< 4.1')
-  spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+  spec.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/appfolio'
 
   spec.add_dependency('holidays', ['>= 8.3', '< 9'])
 end

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   tags:
     - oss
   annotations:
-    appfolio.com/package-location: url:https://rubygems.org/gems/ae_bank_days
+    appfolio.com/package-location: url:https://github.com/appfolio/ae_bank_days/pkgs/rubygems/ae_bank_days
     appfolio.com/package-type: gem
     circleci.com/project-slug: github/appfolio/ae_bank_days
   name: ae-bank-days


### PR DESCRIPTION
## Summary
Migrate Ruby gem source from rubygems.org to JFrog as part of org-wide JFrog migration.

## Changes
- Replaced `source 'https://rubygems.org'` with JFrog URL in Gemfile
- Added `public-packages` orb and setup step to CircleCI config
- Added `context: appfolio_test_context` to CircleCI jobs
- Updated `allowed_push_host` in gemspec to GitHub Packages
- Updated `package-location` in catalog-info.yaml to GitHub Packages
- Created `.github/dependabot.yaml` with JFrog registry configuration

## Why
AppFolio is migrating from RubyGems.org to JFrog for Ruby dependency installation.
Jira Issue: https://appfolio.atlassian.net/browse/BANK-2106

## Test Plan
- CI passes with the new gem source configuration